### PR TITLE
Extend behavior for g:bufferline_show_bufnr

### DIFF
--- a/autoload/bufferline.vim
+++ b/autoload/bufferline.vim
@@ -28,7 +28,7 @@ function! s:generate_names()
 
       if !skip
         let name = ''
-        if g:bufferline_show_bufnr
+        if g:bufferline_show_bufnr != 0 && g:bufferline_status_info.count >= g:bufferline_show_bufnr
           let name =  i . ':'
         endif
         let name .= fname . modified


### PR DESCRIPTION
Changed meaning of g:bufferline_show_bufnr to the minimal number of buffers required to show buffer numbers. 0 still turns off buffer numbers.
This is useful when user doesn't want buffer number to show up when there is only one buffer: Achieved by setting g:bufferline_show_bufnr to 2.
I don't think that anyone would use greater values, but anyway it's nice to have feature.
