### PR TITLE
Add two options, g:bufferline_sort_function and g:bufferline_hide_active_buffer

### DIFF
--- a/autoload/bufferline.vim
+++ b/autoload/bufferline.vim
@@ -58,7 +58,7 @@ function! s:generate_names()
 
       let names[nameindex][1] = name
 
-      if current_buffer == buffernum && g:bufferline_hide_active_buffer == 1
+      if current_buffer == buffer_num && g:bufferline_hide_active_buffer == 1
         if nameindex == 0
           let names = names[nameindex+1:]
         elseif nameindex == len(names)-1

--- a/autoload/bufferline.vim
+++ b/autoload/bufferline.vim
@@ -38,13 +38,14 @@ function! s:generate_names()
   endif
 
   let nameindex = 0
+  let labelnum = 1
   while nameindex < len(names)
       let buffer_num = names[nameindex][0]
       let fname = names[nameindex][1]
 
       let name = ''
       if g:bufferline_show_bufnr != 0 && g:bufferline_status_info.count >= g:bufferline_show_bufnr
-        let name =  (nameindex+1) . ':'
+        let name =  labelnum . ':'
       endif
       let name .= fname . modified
 
@@ -57,7 +58,19 @@ function! s:generate_names()
 
       let names[nameindex][1] = name
 
+      if current_buffer == buffernum && g:bufferline_hide_active_buffer == 1
+        if nameindex == 0
+          let names = names[nameindex+1:]
+        elseif nameindex == len(names)-1
+          let names = names[:nameindex-1]
+        else
+          let names = names[:nameindex-1] + names[nameindex+1:]
+        endif
+        let nameindex -= 1
+      endif
+
       let nameindex += 1
+      let labelnum += 1
   endwhile
 
   if len(names) > 1

--- a/autoload/bufferline.vim
+++ b/autoload/bufferline.vim
@@ -6,16 +6,16 @@ let s:window_start = 0
 
 function! s:generate_names()
   let names = []
-  let i = 1
+  let buffer_num = 1
   let last_buffer = bufnr('$')
   let current_buffer = bufnr('%')
-  while i <= last_buffer
-    if bufexists(i) && buflisted(i)
+  while buffer_num <= last_buffer
+    if bufexists(buffer_num) && buflisted(buffer_num)
       let modified = ' '
-      if getbufvar(i, '&mod')
+      if getbufvar(buffer_num, '&mod')
         let modified = g:bufferline_modified
       endif
-      let fname = fnamemodify(bufname(i), g:bufferline_fname_mod)
+      let fname = fnamemodify(bufname(buffer_num), g:bufferline_fname_mod)
       let fname = substitute(fname, "%", "%%", "g")
 
       let skip = 0
@@ -27,23 +27,37 @@ function! s:generate_names()
       endfor
 
       if !skip
-        let name = ''
-        if g:bufferline_show_bufnr != 0 && g:bufferline_status_info.count >= g:bufferline_show_bufnr
-          let name =  i . ':'
-        endif
-        let name .= fname . modified
-
-        if current_buffer == i
-          let name = g:bufferline_active_buffer_left . name . g:bufferline_active_buffer_right
-          let g:bufferline_status_info.current = name
-        else
-          let name = g:bufferline_separator . name . g:bufferline_separator
-        endif
-
-        call add(names, [i, name])
+        call add(names, [buffer_num, fname])
       endif
     endif
-    let i += 1
+    let buffer_num += 1
+  endwhile
+
+  if g:bufferline_sort_function != ''
+    call sort(names, g:bufferline_sort_function)
+  endif
+
+  let nameindex = 0
+  while nameindex < len(names)
+      let buffer_num = names[nameindex][0]
+      let fname = names[nameindex][1]
+
+      let name = ''
+      if g:bufferline_show_bufnr != 0 && g:bufferline_status_info.count >= g:bufferline_show_bufnr
+        let name =  (nameindex+1) . ':'
+      endif
+      let name .= fname . modified
+
+      if current_buffer == buffer_num
+        let name = g:bufferline_active_buffer_left . name . g:bufferline_active_buffer_right
+        let g:bufferline_status_info.current = name
+      else
+        let name = g:bufferline_separator . name . g:bufferline_separator
+      endif
+
+      let names[nameindex][1] = name
+
+      let nameindex += 1
   endwhile
 
   if len(names) > 1

--- a/doc/bufferline.txt
+++ b/doc/bufferline.txt
@@ -85,6 +85,12 @@ values):
   let g:bufferline_excludes = [] "see source for defaults
 <
 
+* allows you to pass your own sorting function to customize the order of the
+  buffers
+>
+  let g:bufferline_sort_function = 0
+<
+
 ==============================================================================
 STATUSLINE INTEGRATION                               *bufferline-statusline*
 

--- a/doc/bufferline.txt
+++ b/doc/bufferline.txt
@@ -80,6 +80,11 @@ values):
   let g:bufferline_solo_highlight = 0
 <
 
+* denotes whether to show an entry for the active buffer.
+>
+  let g:bufferline_hide_active_buffer = 1
+<
+
 * denotes any exclude patterns.
 >
   let g:bufferline_excludes = [] "see source for defaults

--- a/plugin/bufferline.vim
+++ b/plugin/bufferline.vim
@@ -23,6 +23,7 @@ call s:check_defined('g:bufferline_fixed_index', 1)
 call s:check_defined('g:bufferline_solo_highlight', 0)
 call s:check_defined('g:bufferline_excludes', ['\[vimfiler\]'])
 call s:check_defined('g:bufferline_sort_function', 0)
+call s:check_defined('g:bufferline_hide_active_buffer', 0)
 
 function! bufferline#generate_string()
   return "bufferline#generate_string() is obsolete! Please consult README."

--- a/plugin/bufferline.vim
+++ b/plugin/bufferline.vim
@@ -22,6 +22,7 @@ call s:check_defined('g:bufferline_rotate', 0)
 call s:check_defined('g:bufferline_fixed_index', 1)
 call s:check_defined('g:bufferline_solo_highlight', 0)
 call s:check_defined('g:bufferline_excludes', ['\[vimfiler\]'])
+call s:check_defined('g:bufferline_sort_function', 0)
 
 function! bufferline#generate_string()
   return "bufferline#generate_string() is obsolete! Please consult README."


### PR DESCRIPTION
I'm loving bufferline, but wanted to tweak a couple things.  

I use the [bufstop](https://github.com/mihaifm/bufstop) plugin which I love, and I wanted bufferline to show the buffers in the same order that bufstop uses for its speed toggle.  So, being able to specify a custom sort function made that possible.

Then I added an option to not show the active buffer. My terminal windows aren't usually very wide, and since I already have the name of the file in my status bar (I put bufferline in the command bar), I didn't need it doubled up.  So, this allows you to hide the active buffer from the bufferline list.
