### PR TITLE
fix matching of current buffer inside of line with all buffers

### DIFF
--- a/autoload/bufferline.vim
+++ b/autoload/bufferline.vim
@@ -69,7 +69,7 @@ function! bufferline#get_echo_string()
   endfor
 
   let filename = substitute(g:bufferline_status_info.current, '^\s*\(.\{-}\)\s*$', '\1', '')
-  let index = match(line, '\V\<'.filename.'\>')
+  let index = match(line, '\C\V\<'.filename.'\>')
   let g:bufferline_status_info.count = len(names)
   let g:bufferline_status_info.before = strpart(line, 0, index)
   let g:bufferline_status_info.after = strpart(line, index + len(g:bufferline_status_info.current))


### PR DESCRIPTION
Use word boundaries around current buffer name when try to match in buffer line

For example this commit fixes the issue that when you have two buffers open, `foobar` and `bar`, it highlights the correct buffer.
Before the problem was if you have the `bar` buffer open it highlights the `bar` of `foobar`.

:beers: 
