### PR TITLE
Prevent overwriting Unite status.

### DIFF
--- a/autoload/bufferline.vim
+++ b/autoload/bufferline.vim
@@ -76,6 +76,10 @@ function! bufferline#get_echo_string()
 endfunction
 
 function! s:echo()
+  if &filetype ==# 'unite'
+    return
+  endif
+
   let line = bufferline#get_echo_string()
 
   " 12 is magical and is the threshold for when it doesn't wrap text anymore


### PR DESCRIPTION
Unite.vim uses the command line to show a little status message while interacting with it.

Sadly, in the current state vim-bufferline overwrites this. This is a simple fix that should give preference to Unite.vim when the current buffer is a Unite buffer.