### PR TITLE
Minor cosmetic changes

### DIFF
--- a/autoload/bufferline.vim
+++ b/autoload/bufferline.vim
@@ -11,7 +11,7 @@ function! s:generate_names()
   let current_buffer = bufnr('%')
   while i <= last_buffer
     if bufexists(i) && buflisted(i)
-      let modified = ' '
+      let modified = ''
       if getbufvar(i, '&mod')
         let modified = g:bufferline_modified
       endif

--- a/autoload/bufferline.vim
+++ b/autoload/bufferline.vim
@@ -15,7 +15,14 @@ function! s:generate_names()
       if getbufvar(i, '&mod')
         let modified = g:bufferline_modified
       endif
-      let fname = fnamemodify(bufname(i), g:bufferline_fname_mod)
+      let bname = bufname(i)
+      let btype = getbufvar(i, '&buftype')
+      let fname = '[No Name]'
+      if len(bname) == 0 && len(btype) != 0
+        let fname = '['.btype.']'
+      elseif len(bname) > 0
+        let fname = fnamemodify(bname, g:bufferline_fname_mod)
+      endif
       if g:bufferline_pathshorten != 0
         let fname = pathshorten(fname)
       endif


### PR DESCRIPTION
- Remove the trailing space for unmodified bufers
- Display `[No Name]` for unnamed buffers (at startup)

Without trailing space, it'll look like `[[No Name]]` by default, otherwise `[[No Name] ]` which doesn't look very good. Now why `[No Name]` at all -- why not leave it empty? Open an empty vim instance, do `:badd <file>`. The `[No Name]` buffer won't be replaced, and switching to the other buffer will make the unnamed buffer look bad (or not at all).

I didn't want to add more global options for these, but would there be users who care about these changes?
