### PR TITLE
expand g:bufferline_fixed_position

### DIFF
--- a/autoload/bufferline/algos/fixed_position.vim
+++ b/autoload/bufferline/algos/fixed_position.vim
@@ -1,7 +1,16 @@
 " pins the active buffer to a specific index in the list
 function! bufferline#algos#fixed_position#modify(names)
   let current = bufnr('%')
-  while a:names[g:bufferline_fixed_index][0] != current
+  if abs(g:bufferline_fixed_index) >= len(a:names)
+    if g:bufferline_fixed_index < 0
+      let l:bufferline_fixed_index = 0
+    else
+      let l:bufferline_fixed_index = -1
+    endif
+  else
+    let l:bufferline_fixed_index = g:bufferline_fixed_index
+  endif
+  while a:names[l:bufferline_fixed_index][0] != current
     let first = remove(a:names, 0)
     call add(a:names, first)
   endwhile

--- a/doc/bufferline.txt
+++ b/doc/bufferline.txt
@@ -53,6 +53,11 @@ values):
 >
   let g:bufferline_fixed_index =  0 "always first
   let g:bufferline_fixed_index =  1 "always second (default)
+  let g:bufferline_fixed_index =  2 "always third (last when there are less
+    \ than 3 buffers)
+  ...
+  let g:bufferline_fixed_index = -2 "always second last (first when there are
+    \ only one buffer)
   let g:bufferline_fixed_index = -1 "always last
 <
 


### PR DESCRIPTION
Current code will raise an error when there is only one buffer and at same time `g:bufferline_fixed_index` is mistakenly set to `2` (one would likely make it as the other two options given in the doc are `0` and `1`).
The pr checks if there are enough buffers and expands `g:bufferline_fixed_index` to accept all integers.