### PR TITLE
g:Bufferline_get_buffers_list

### DIFF
--- a/autoload/bufferline.vim
+++ b/autoload/bufferline.vim
@@ -4,22 +4,12 @@ let s:updatetime = &updatetime
 " keep track of scrollinf window start
 let s:window_start = 0
 
-function! s:get_buffers_list()
-  if exists('g:bufferline_get_buffers_list')
-    let result = g:bufferline_get_buffers_list()
-    " echo result
-    return result
-  else
-    return range(1, bufnr('$'))
-  endif
-endfunction
-
 function! s:generate_names()
   let names = []
   let i = 1
   let last_buffer = bufnr('$')
   let current_buffer = bufnr('%')
-  for i in s:get_buffers_list()
+  for i in g:Bufferline_get_buffers_list()
     if bufexists(i) && buflisted(i)
       let modified = ' '
       if getbufvar(i, '&mod')

--- a/autoload/bufferline.vim
+++ b/autoload/bufferline.vim
@@ -4,12 +4,22 @@ let s:updatetime = &updatetime
 " keep track of scrollinf window start
 let s:window_start = 0
 
+function! s:get_buffers_list()
+  if exists('g:bufferline_get_buffers_list')
+    let result = g:bufferline_get_buffers_list()
+    " echo result
+    return result
+  else
+    return range(1, bufnr('$'))
+  endif
+endfunction
+
 function! s:generate_names()
   let names = []
   let i = 1
   let last_buffer = bufnr('$')
   let current_buffer = bufnr('%')
-  while i <= last_buffer
+  for i in s:get_buffers_list()
     if bufexists(i) && buflisted(i)
       let modified = ' '
       if getbufvar(i, '&mod')
@@ -46,8 +56,7 @@ function! s:generate_names()
         call add(names, [i, name])
       endif
     endif
-    let i += 1
-  endwhile
+  endfor
 
   if len(names) > 1
     if g:bufferline_rotate == 1

--- a/plugin/bufferline.vim
+++ b/plugin/bufferline.vim
@@ -9,6 +9,10 @@ function! s:check_defined(variable, default)
   endif
 endfunction
 
+function! s:get_buffers_list_default()
+  return range(1, bufnr('$'))
+endfunction
+
 call s:check_defined('g:bufferline_active_buffer_left', '[')
 call s:check_defined('g:bufferline_active_buffer_right', ']')
 call s:check_defined('g:bufferline_separator', ' ')
@@ -23,6 +27,7 @@ call s:check_defined('g:bufferline_fixed_index', 1)
 call s:check_defined('g:bufferline_solo_highlight', 0)
 call s:check_defined('g:bufferline_excludes', ['\[vimfiler\]'])
 call s:check_defined('g:bufferline_pathshorten', 0)
+call s:check_defined('g:Bufferline_get_buffers_list', function('s:get_buffers_list_default'))
 
 function! bufferline#generate_string()
   return "bufferline#generate_string() is obsolete! Please consult README."


### PR DESCRIPTION
Hi,

I created a tiny [plugin](https://github.com/cosmas375/nvim-buffer-sorter) that allows users to sort buffers, and I would like to integrate it with vim-bufferline.

In this PR, a new property **g:Bufferline_get_buffers_list** was added to the config. Its value is a function that returns a sorted array of buffer ids. By default it returns a range from 1 to the max buffer id (as before).

Thank you for your attention :)